### PR TITLE
Tftft patch 2.03 update

### DIFF
--- a/HungerRevamped.cs
+++ b/HungerRevamped.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Il2Cpp;
 
 namespace HungerRevamped {
 	public class HungerRevamped {

--- a/HungerRevamped.csproj
+++ b/HungerRevamped.csproj
@@ -1,88 +1,36 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{76E55258-60B2-4882-8E97-3840EB706DAE}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>HungerRevamped</RootNamespace>
-    <AssemblyName>HungerRevamped</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Il2Cppmscorlib">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Il2CppSystem">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="MelonLoader">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="ModSettings">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="UnhollowerBaseLib">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnhollowerRuntimeLib">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="CustomModeSettings.cs" />
-    <Compile Include="FoodPoisoningTuple.cs" />
-    <Compile Include="HungerRevampedMod.cs" />
-    <Compile Include="HungerTuple.cs" />
-    <Compile Include="MenuSettings.cs" />
-    <Compile Include="Patches\CookingConditionFix.cs" />
-    <Compile Include="Patches\DebugCommandPatches.cs" />
-    <Compile Include="HungerRevamped.cs" />
-    <Compile Include="HungerRevampedSaveDataProxy.cs" />
-    <Compile Include="Patches\ExploitableCookingSkillFix.cs" />
-    <Compile Include="Patches\FoodPoisoningPatches.cs" />
-    <Compile Include="Patches\GameStatePatches.cs" />
-    <Compile Include="Patches\HarvestFoodForCanPatch.cs" />
-    <Compile Include="Patches\PreventCookingRuinedFoodPatches.cs" />
-    <Compile Include="Patches\PreventEatingRuinedFood.cs" />
-    <Compile Include="Patches\StatusBarPatches.cs" />
-    <Compile Include="Patches\UIPanelPatches.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Patches\SerializationPatches.cs" />
-    <Compile Include="Tuning.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="README.md" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<!--This is an xml comment. Comments have no impact on compiling.-->
+
+	<PropertyGroup>
+		<!--This is the .NET version the mod will be compiled with. Don't change it.-->
+		<TargetFramework>net6.0</TargetFramework>
+
+		<!--This tells the compiler to use the latest C# version.-->
+		<LangVersion>Latest</LangVersion>
+
+		<!--This adds global usings for a few common System namespaces.-->
+		<ImplicitUsings>enable</ImplicitUsings>
+
+		<!--This enables nullable annotation and analysis. It's good coding form.-->
+		<Nullable>enable</Nullable>
+
+		<!--This tells the compiler to use assembly attributes instead of generating its own.-->
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+
+		<!--PDB files give line numbers in stack traces (errors). This is useful for debugging. There are 3 options:-->
+		<!--full has a pdb file created beside the dll.-->
+		<!--embedded has the pdb data embedded within the dll. This is useful because bug reports will then have line numbers.-->
+		<!--none skips creation of pdb data.-->
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<!--This is the of packages that the mod references.-->
+	<ItemGroup>
+		<!--This package contains almost everything a person could possibly need to reference while modding.-->
+		<PackageReference Include="STBlade.Modding.TLD.Il2CppAssemblies.Windows" Version="2.10.0" />
+		<PackageReference Include="stblade.Modding.TLD.ModData" Version="1.5.1" />
+		<PackageReference Include="STBlade.Modding.TLD.ModSettings" Version="1.9.0" />
+		<!--The package version here in this template may be outdated and need to be updated. Visual Studio can update package versions automatically.-->
+		<!--If the mod references any other mods (such as ModSettings), that NuGet package will also need to be listed here.-->
+	</ItemGroup>
 </Project>

--- a/HungerRevamped.csproj
+++ b/HungerRevamped.csproj
@@ -33,4 +33,7 @@
 		<!--The package version here in this template may be outdated and need to be updated. Visual Studio can update package versions automatically.-->
 		<!--If the mod references any other mods (such as ModSettings), that NuGet package will also need to be listed here.-->
 	</ItemGroup>
+	<ItemGroup>
+	  <Folder Include="Utils\" />
+	</ItemGroup>
 </Project>

--- a/HungerRevampedMod.cs
+++ b/HungerRevampedMod.cs
@@ -2,12 +2,16 @@
 using UnityEngine;
 
 namespace HungerRevamped {
-	internal class HungerRevampedMod : MelonMod {
+    internal sealed class HungerRevampedMod : MelonMod
+    {
+        internal static SaveDataManager sdm = new SaveDataManager();
 
-		public override void OnApplicationStart() {
-			CustomModeSettings.Initialize();
-			MenuSettings.Initialize();
-			Debug.Log($"[{Info.Name}] version {Info.Version} loaded!");
-		}
-	}
+        public override void OnInitializeMelon()
+        {
+            CustomModeSettings.Initialize();
+            MenuSettings.Initialize();
+            Debug.Log($"[{Info.Name}] version {Info.Version} loaded");
+            new MelonLoader.MelonLogger.Instance($"{Info.Name}").Msg($"Version {Info.Version} loaded");
+        }
+    }
 }

--- a/Patches/CookingConditionFix.cs
+++ b/Patches/CookingConditionFix.cs
@@ -1,15 +1,30 @@
 ﻿using HarmonyLib;
 using UnityEngine;
+using Il2Cpp;
 
-namespace HungerRevamped {
+namespace HungerRevamped
+{
 
-	[HarmonyPatch(typeof(CookingPotItem), "SetCookedGearProperties")]
-	internal class CookingConditionFix {
+    [HarmonyPatch(typeof(CookingPotItem), "SetCookedGearProperties")]
+    internal class CookingConditionFix
+    {
 
-		private static void Postfix(GearItem rawItem, GearItem cookedItem) {
-			if (MenuSettings.settings.cookingDoublesCondition && rawItem && cookedItem) {
-				cookedItem.m_CurrentHP = cookedItem.m_MaxHP * Mathf.Clamp01(2 * rawItem.m_CurrentHP / rawItem.m_MaxHP);
-			}
-		}
-	}
+        private static readonly MelonLoader.MelonLogger.Instance logger = new MelonLoader.MelonLogger.Instance(BuildInfo.ModName);
+
+        private static void Postfix(GearItem rawItem, GearItem cookedItem)
+        {            
+            if (MenuSettings.settings.cookingDoublesCondition && rawItem && cookedItem)
+            {
+                logger.Msg($"Applying cooking item doubles condition fix");
+
+                var rawItemHp = rawItem.CurrentHP;
+                var rawItemMax = rawItem.GearItemData.m_MaxHP;
+                var cookedItemMax = cookedItem.GearItemData.m_MaxHP;
+                var cookedResultHp = cookedItemMax * Mathf.Clamp01(2 * rawItemHp / rawItemMax);
+
+                logger.Msg($"raw hp: {rawItemHp}, raw max: {rawItemMax}, cooked max: {cookedItemMax}, calculated: {cookedResultHp}");
+                cookedItem.CurrentHP = cookedResultHp;
+            }
+        }
+    }
 }

--- a/Patches/DebugCommandPatches.cs
+++ b/Patches/DebugCommandPatches.cs
@@ -1,6 +1,6 @@
 ﻿using HarmonyLib;
 using UnityEngine;
-using System;
+using Il2Cpp;
 
 namespace HungerRevamped {
 	internal static class DebugCommandPatches {

--- a/Patches/ExploitableCookingSkillFix.cs
+++ b/Patches/ExploitableCookingSkillFix.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using Il2Cpp;
 
 namespace HungerRevamped {
 

--- a/Patches/FoodPoisoningPatches.cs
+++ b/Patches/FoodPoisoningPatches.cs
@@ -28,7 +28,7 @@ namespace HungerRevamped {
 
 		// Wake the player up when applying (deferred) food poisoning while asleep
 		private static void Postfix() {
-			if (GameManager.GetPlayerManagerComponent().PlayerIsDead() || InterfaceManager.m_Panel_ChallengeComplete.IsEnabled()) return;
+			if (GameManager.GetPlayerManagerComponent().PlayerIsDead() || InterfaceManager.IsPanelEnabled<Panel_ChallengeComplete>()) return;
 			if (GameManager.InCustomMode() && !GameManager.GetCustomMode().m_EnableFoodPoisoning) return;
 			if (disableFoodPoisoning) return;
 

--- a/Patches/FoodPoisoningPatches.cs
+++ b/Patches/FoodPoisoningPatches.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using UnityEngine;
+using Il2Cpp;
 
 namespace HungerRevamped {
 
@@ -27,7 +28,7 @@ namespace HungerRevamped {
 
 		// Wake the player up when applying (deferred) food poisoning while asleep
 		private static void Postfix() {
-			if (GameManager.GetPlayerManagerComponent().PlayerIsDead() || InterfaceManager.IsPanelEnabled<Panel_ChallengeComplete>()) return;
+			if (GameManager.GetPlayerManagerComponent().PlayerIsDead() || InterfaceManager.m_Panel_ChallengeComplete.IsEnabled()) return;
 			if (GameManager.InCustomMode() && !GameManager.GetCustomMode().m_EnableFoodPoisoning) return;
 			if (disableFoodPoisoning) return;
 
@@ -74,9 +75,9 @@ namespace HungerRevamped {
 
 			if (giveFoodPoisoning) {
 				if (MenuSettings.settings.delayedFoodPoisoning) {
-					HungerRevamped.Instance.AddFoodPoisoningCall(foodItemEaten.m_LocalizedDisplayName.m_LocalizationID);
+					HungerRevamped.Instance.AddFoodPoisoningCall(foodItemEaten.GearItemData.DisplayNameLocID);
 				} else {
-					GameManager.GetFoodPoisoningComponent().FoodPoisoningStart(foodItemEaten.m_LocalizedDisplayName.m_LocalizationID, true, false);
+					GameManager.GetFoodPoisoningComponent().FoodPoisoningStart(foodItemEaten.GearItemData.DisplayNameLocID, true, false);
 				}
 			}
 		}
@@ -100,7 +101,7 @@ namespace HungerRevamped {
 
 			float chanceFoodPoisioning = GetFoodPoisoningChance(lowChance, highChance, condition) / 100f;
 			float scaledChance = 1f - Mathf.Pow(1f - chanceFoodPoisioning, proportionEaten);
-			return Random.value < scaledChance;
+			return UnityEngine.Random.value < scaledChance;
 		}
 
 		private static float GetFoodPoisoningChance(float lowChance, float highChance, float condition) {

--- a/Patches/GameStatePatches.cs
+++ b/Patches/GameStatePatches.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using Il2Cpp;
 
 namespace HungerRevamped {
 	internal static class GameStatePatches {

--- a/Patches/HarvestFoodForCanPatch.cs
+++ b/Patches/HarvestFoodForCanPatch.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using UnityEngine;
+using Il2Cpp;
 
 namespace HungerRevamped {
 	internal static class HarvestFoodForCanPatch {

--- a/Patches/PreventCookingRuinedFoodPatches.cs
+++ b/Patches/PreventCookingRuinedFoodPatches.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using System;
+using Il2Cpp;
 
 namespace HungerRevamped {
 	internal static class PreventCookingRuinedFoodPatches {

--- a/Patches/PreventEatingRuinedFood.cs
+++ b/Patches/PreventEatingRuinedFood.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using HarmonyLib;
+using Il2Cpp;
 
 namespace HungerRevamped {
 

--- a/Patches/StatusBarPatches.cs
+++ b/Patches/StatusBarPatches.cs
@@ -39,8 +39,8 @@ namespace HungerRevamped {
 
 				// Starving hunger bar colors
 				if (fillValue < Tuning.hungerLevelStarving) {
-					__instance.m_OuterBoxSprite.color = GameManager.GetInterfaceManager().m_StatusOuterBoxEmptyColor;
-					Utils.SetActive(__instance.m_SpriteWhenEmpty.gameObject, true);
+					__instance.m_OuterBoxSprite.color = InterfaceManager.GetInstance().m_StatusOuterBoxEmptyColor;
+                    Utils.SetActive(__instance.m_SpriteWhenEmpty.gameObject, true);
 					__instance.SetActiveBacksplash(__instance.m_BacksplashDepleted);
 				}
 			}

--- a/Patches/StatusBarPatches.cs
+++ b/Patches/StatusBarPatches.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using Il2Cpp;
 
 namespace HungerRevamped {
 	internal static class StatusBarPatches {
@@ -38,7 +39,7 @@ namespace HungerRevamped {
 
 				// Starving hunger bar colors
 				if (fillValue < Tuning.hungerLevelStarving) {
-					__instance.m_OuterBoxSprite.color = InterfaceManager.GetInstance().m_StatusOuterBoxEmptyColor;
+					__instance.m_OuterBoxSprite.color = GameManager.GetInterfaceManager().m_StatusOuterBoxEmptyColor;
 					Utils.SetActive(__instance.m_SpriteWhenEmpty.gameObject, true);
 					__instance.SetActiveBacksplash(__instance.m_BacksplashDepleted);
 				}

--- a/Patches/UIPanelPatches.cs
+++ b/Patches/UIPanelPatches.cs
@@ -14,9 +14,14 @@ namespace HungerRevamped {
 
 		// Panel_FirstAid
 
-		[HarmonyPatch(typeof(Panel_FirstAid), "Start")]
+		[HarmonyPatch(typeof(Panel_FirstAid), "Enable", new Type[] { typeof(bool) })]
 		private static class AddStoredCaloriesLabel {
+			private static bool initialized = false;
+
 			private static void Prefix(Panel_FirstAid __instance) {
+				if (initialized) return;
+				initialized = true;
+
 				Transform airTempRow = __instance.m_AirTempLabel.transform.parent;
 				Transform windChillRow = __instance.m_WindchillLabel.transform.parent;
 				Transform feelsLikeRow = __instance.m_FeelsLikeLabel.transform.parent;
@@ -105,9 +110,14 @@ namespace HungerRevamped {
 			}
 		}
 
-		[HarmonyPatch(typeof(Panel_Rest), "Start", new Type[0])]
+		[HarmonyPatch(typeof(Panel_Rest), "Enable", new Type[] { typeof(bool) })]
 		private static class ChangeRestHungerLabel {
+			private static bool initialized = false;
+
 			private static void Postfix(Panel_Rest __instance) {
+				if (initialized) return;
+				initialized = true;
+
 				Transform parentTransform = __instance.m_EstimatedCaloriesBurnedLabel.transform.parent;
 				GameObject gameObject = parentTransform.Find("Label_CaloriesBurned").gameObject;
 				UILocalize localize = gameObject.GetComponent<UILocalize>();
@@ -224,9 +234,14 @@ namespace HungerRevamped {
 
 		// Panel_SnowShelterBuild
 
-		[HarmonyPatch(typeof(Panel_SnowShelterBuild), "Start")]
+		[HarmonyPatch(typeof(Panel_SnowShelterBuild), "Enable", new Type[] { typeof(bool) })]
 		private static class SetSnowShelterBuildLabels {
+			private static bool initialized = false;
+
 			private static void Postfix(Panel_SnowShelterBuild __instance) {
+				if (initialized) return;
+				initialized = true;
+
 				UILocalize calorieStoreHeader = __instance.m_CurrentCaloriesLabel.GetComponent<UILocalize>();
 				calorieStoreHeader.key = "GAMEPLAY_CalorieStore";
 
@@ -268,9 +283,14 @@ namespace HungerRevamped {
 
 		// Panel_SnowShelterInteract
 
-		[HarmonyPatch(typeof(Panel_SnowShelterInteract), "Start")]
+		[HarmonyPatch(typeof(Panel_SnowShelterInteract), "Enable", new Type[] { typeof(bool) })]
 		private static class SetSnowShelterInteractLabels {
+			private static bool initialized = false;
+
 			private static void Postfix(Panel_SnowShelterInteract __instance) {
+				if (initialized) return;
+				initialized = true;
+
 				UILocalize calorieStoreHeader = __instance.m_CurrentCaloriesLabel.GetComponent<UILocalize>();
 				calorieStoreHeader.key = "GAMEPLAY_CalorieStore";
 

--- a/Patches/UIPanelPatches.cs
+++ b/Patches/UIPanelPatches.cs
@@ -44,7 +44,7 @@ namespace HungerRevamped {
 
 			private static void Postfix(Panel_FirstAid __instance) {
 				Color red = __instance.m_PoorHealthStatusColor;
-				Color green = InterfaceManager.m_Panel_ActionsRadial.m_FirstAidBuffColor;
+				Color green = InterfaceManager.m_FirstAidBuffColor;
 
 				// Replace hunger bar calories with stored calories
 				double storedCalories = HungerRevamped.Instance.storedCalories;

--- a/Patches/UIPanelPatches.cs
+++ b/Patches/UIPanelPatches.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using HarmonyLib;
 using UnityEngine;
+using Il2Cpp;
 
 namespace HungerRevamped {
 
@@ -13,14 +14,9 @@ namespace HungerRevamped {
 
 		// Panel_FirstAid
 
-		[HarmonyPatch(typeof(Panel_FirstAid), "Enable", new Type[] { typeof(bool) })]
+		[HarmonyPatch(typeof(Panel_FirstAid), "Start")]
 		private static class AddStoredCaloriesLabel {
-			private static bool initialized = false;
-
 			private static void Prefix(Panel_FirstAid __instance) {
-				if (initialized) return;
-				initialized = true;
-
 				Transform airTempRow = __instance.m_AirTempLabel.transform.parent;
 				Transform windChillRow = __instance.m_WindchillLabel.transform.parent;
 				Transform feelsLikeRow = __instance.m_FeelsLikeLabel.transform.parent;
@@ -48,7 +44,7 @@ namespace HungerRevamped {
 
 			private static void Postfix(Panel_FirstAid __instance) {
 				Color red = __instance.m_PoorHealthStatusColor;
-				Color green = InterfaceManager.m_FirstAidBuffColor;
+				Color green = InterfaceManager.m_Panel_ActionsRadial.m_FirstAidBuffColor;
 
 				// Replace hunger bar calories with stored calories
 				double storedCalories = HungerRevamped.Instance.storedCalories;
@@ -109,14 +105,9 @@ namespace HungerRevamped {
 			}
 		}
 
-		[HarmonyPatch(typeof(Panel_Rest), "Enable", new Type[] { typeof(bool) })]
+		[HarmonyPatch(typeof(Panel_Rest), "Start", new Type[0])]
 		private static class ChangeRestHungerLabel {
-			private static bool initialized = false;
-
 			private static void Postfix(Panel_Rest __instance) {
-				if (initialized) return;
-				initialized = true;
-
 				Transform parentTransform = __instance.m_EstimatedCaloriesBurnedLabel.transform.parent;
 				GameObject gameObject = parentTransform.Find("Label_CaloriesBurned").gameObject;
 				UILocalize localize = gameObject.GetComponent<UILocalize>();
@@ -233,14 +224,9 @@ namespace HungerRevamped {
 
 		// Panel_SnowShelterBuild
 
-		[HarmonyPatch(typeof(Panel_SnowShelterBuild), "Enable", new Type[] { typeof(bool) })]
+		[HarmonyPatch(typeof(Panel_SnowShelterBuild), "Start")]
 		private static class SetSnowShelterBuildLabels {
-			private static bool initialized = false;
-
 			private static void Postfix(Panel_SnowShelterBuild __instance) {
-				if (initialized) return;
-				initialized = true;
-
 				UILocalize calorieStoreHeader = __instance.m_CurrentCaloriesLabel.GetComponent<UILocalize>();
 				calorieStoreHeader.key = "GAMEPLAY_CalorieStore";
 
@@ -282,14 +268,9 @@ namespace HungerRevamped {
 
 		// Panel_SnowShelterInteract
 
-		[HarmonyPatch(typeof(Panel_SnowShelterInteract), "Enable", new Type[] { typeof(bool) })]
+		[HarmonyPatch(typeof(Panel_SnowShelterInteract), "Start")]
 		private static class SetSnowShelterInteractLabels {
-			private static bool initialized = false;
-
 			private static void Postfix(Panel_SnowShelterInteract __instance) {
-				if (initialized) return;
-				initialized = true;
-
 				UILocalize calorieStoreHeader = __instance.m_CurrentCaloriesLabel.GetComponent<UILocalize>();
 				calorieStoreHeader.key = "GAMEPLAY_CalorieStore";
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -12,7 +12,14 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("76e55258-60b2-4882-8e97-3840eb706dae")]
-[assembly: AssemblyVersion("1.10.0.0")]
-[assembly: AssemblyFileVersion("1.10.0.0")]
-[assembly: MelonInfo(typeof(HungerRevamped.HungerRevampedMod), "HungerRevamped", "1.10", "zeobviouslyfakeacc")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: MelonInfo(typeof(HungerRevamped.HungerRevampedMod), BuildInfo.ModName, BuildInfo.ModVersion, BuildInfo.ModAuthor)]
 [assembly: MelonGame("Hinterland", "TheLongDark")]
+
+internal static class BuildInfo
+{
+    internal const string ModName = "HungerRevamped";
+    internal const string ModAuthor = "zeobviouslyfakeacc";
+    internal const string ModVersion = "2.0";
+}

--- a/Utils/SaveDataManager.cs
+++ b/Utils/SaveDataManager.cs
@@ -1,0 +1,22 @@
+﻿using ModData;
+
+namespace HungerRevamped
+{
+    internal class SaveDataManager
+    {
+
+        ModDataManager dm = new ModDataManager("HungerRevamped");
+        
+        public bool Save(string data)
+        {
+            return dm.Save(data, null);
+        }
+
+        public string? LoadData()
+        {
+            string? data = dm.Load(null);
+            return data;
+        }
+
+    }
+}


### PR DESCRIPTION
Update to make HungerRevamped compatible with the post-TFTFT release. Tested on latest game version 2.03.

Modifications are fairly limited:

- Updated assemblies and dependencies for newest version of MelonLoader and .NET 6
- Changed a few method calls to use updated APIs, particularly in Patches
- Largest change is bringing in ModData as a dependency as a simpler way to handle persistence in the new patch